### PR TITLE
chore: PR 디스코드 알림 구현

### DIFF
--- a/.github/workflows/devths-pr.yml
+++ b/.github/workflows/devths-pr.yml
@@ -1,0 +1,112 @@
+name: Devths-Cloud PR 파이프라인
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - release/*
+      - main
+
+jobs:
+  # 0. main 브랜치 보호: release/hotfix/*만 PR 허용
+  main-branch-guard:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: main PR 브랜치 검증
+        run: |
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
+
+          echo "📌 대상 브랜치: $BASE"
+          echo "📌 소스 브랜치: $HEAD"
+
+          # main이 아닐 땐 통과
+          if [ "$BASE" != "main" ]; then
+            echo "✅ 브랜치 정책 통과 (main 아님)"
+            exit 0
+          fi
+
+          # main일 때 허용 브랜치: release/*
+          if [[ "$HEAD" =~ ^release\/.+$ || "$HEAD" =~ ^hotfix\/.+$ ]]; then
+            echo "✅ 브랜치 정책 통과 (허용된 소스 브랜치)"
+            exit 0
+          fi
+
+          echo "❌ 정책 위반: main에는 release/* 또는 hotfix/* 브랜치만 PR 가능"
+          exit 1
+
+  # 2. 디스코드 알림
+  notify-discord:
+    runs-on: ubuntu-22.04
+    needs: [main-branch-guard]
+    if: always()
+    steps:
+      - name: 데이터 준비
+        id: prep
+        env:
+          USER_MAP: ${{ secrets.USER_MAP_JSON }}
+        run: |
+          # 브랜치 가드 재평가 (main은 release/*/hotfix/*만 허용)
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
+          if [ "$BASE" == "main" ] && [[ ! "$HEAD" =~ ^release\/.+$ && ! "$HEAD" =~ ^hotfix\/.+$ ]]; then
+            GUARD_ALLOWED=false
+            GUARD_REASON="main에는 release/* 또는 hotfix/* 브랜치만 PR 가능"
+          else
+            GUARD_ALLOWED=true
+            GUARD_REASON="정책 통과"
+          fi
+
+          echo "branch_guard_allowed=$GUARD_ALLOWED" >> $GITHUB_OUTPUT
+          echo "branch_guard_reason=$GUARD_REASON" >> $GITHUB_OUTPUT
+
+          # 1. 작성자 멘션화
+          LOGIN_ID="${{ github.event.pull_request.user.login }}"
+          AUTHOR_RAW=$(echo "$USER_MAP" | jq -r --arg id "$LOGIN_ID" '.[$id] // $id')
+          [[ $AUTHOR_RAW =~ (<@[^>]+>) ]] && AUTHOR_TAG="${BASH_REMATCH[1]}" || AUTHOR_TAG="$AUTHOR_RAW"
+          echo "author=$AUTHOR_TAG" >> $GITHUB_OUTPUT
+
+          # 2. 리뷰어 멘션화
+          REVIEWERS_JSON='${{ toJson(github.event.pull_request.requested_reviewers) }}'
+          REVIEWER_TAGS=$(echo "$REVIEWERS_JSON" | jq -r --argjson map "$USER_MAP" '
+            [.[].login | ($map[.] // .)] 
+            | map(if test("<@[^>]+>") then sub(".*(?=<@)"; "") | sub("(?<=>).*"; "") else . end)
+            | join(", ")
+          ')
+          echo "reviewers=${REVIEWER_TAGS:-없음}" >> $GITHUB_OUTPUT
+
+          # 3. 작업 내용 요약 (정규식 수정 완료)
+          PR_RAW_BODY=$(cat << 'EOF'
+          ${{ github.event.pull_request.body }}
+          EOF
+          )
+          DESC=$(echo "$PR_RAW_BODY" | \
+            perl -0777 -pe 's///gs' | \
+            sed 's/이 PR에서 변경된 내용을 간략히 작성해주세요\.//g' | \
+            sed -n '/## 📌 작업한 내용/,/## 🔍 참고 사항/p' | \
+            sed '1d;$d' | \
+            xargs | \
+            head -c 300)
+          echo "description=${DESC:-내용 없음}" >> $GITHUB_OUTPUT
+
+      - name: Discord 알림 전송
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && 'success' || 'failure' }}
+          title: "${{ github.event.pull_request.base.ref }} Cloud PR [${{ steps.prep.outputs.branch_guard_allowed == 'true' && '✅성공' || '❌실패' }}]"
+          description: |
+            **PR 제목**: ${{ github.event.pull_request.title }}
+            **브랜치 가드**: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && '✅ 통과' || '❌ 차단' }} (이유: ${{ steps.prep.outputs.branch_guard_reason }})
+            **작성자**: ${{ steps.prep.outputs.author }}
+            **리뷰어**: ${{ steps.prep.outputs.reviewers }}
+            **작업 내용**: ${{ steps.prep.outputs.description }}...
+            **경로**: `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
+
+            **📊 상세 결과**:
+            - Branch Guard: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && ' ✅' || ' ❌' }}
+
+            **🔗 링크**: [PR 확인하기](${{ github.event.pull_request.html_url }})
+          color: "${{ steps.prep.outputs.branch_guard_allowed == 'true' && 65280 || 16711680 }}"
+          username: GitHub Cloud Bot
+          avatar_url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png


### PR DESCRIPTION
## 📌 작업한 내용
PR 생성 및 변경 시 Discord 채널로 알림을 보내는 GitHub Actions 워크플로우를 추가했습니다. 

## 🔍 참고 사항
- Discord Webhook URL은 GitHub Actions Secrets에 저장하여 보안을 유지했습니다.
- 워크플로우는 특정 브랜치(예: main, develop)에 대한 PR 이벤트만 감지하도록 필터링했습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
#28 chore: PR 디스코드 알림 구현

## ✅ 체크리스트
- [x] 테스트 레포지토리에서 PR 생성/수정/종료 이벤트 알림 정상 수신 확인.  
- [x] DISCORD_WEBHOOK_URL 등 필요한 Secrets 설정 완료.  
- [x] 불필요한 브랜치/이벤트에 대한 알림이 가지 않도록 필터 조건 검토.