### PR TITLE
feat(#38): add k8s platform network configs

### DIFF
--- a/k8s/platform/cert-manager/cluster-issuer.yaml
+++ b/k8s/platform/cert-manager/cluster-issuer.yaml
@@ -1,0 +1,38 @@
+---
+# Let's Encrypt Staging (테스트용 - rate limit 없음, 먼저 이걸로 검증)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: ${ACME_EMAIL}
+    privateKeySecretRef:
+      name: letsencrypt-staging-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: devths-gateway
+                namespace: nginx-gateway
+                kind: Gateway
+---
+# Let's Encrypt Production (실제 인증서)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ${ACME_EMAIL}
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: devths-gateway
+                namespace: nginx-gateway
+                kind: Gateway

--- a/k8s/platform/network-policy/network-policies.yaml
+++ b/k8s/platform/network-policy/network-policies.yaml
@@ -1,0 +1,385 @@
+---
+# Devths V3 nonprod NetworkPolicy
+# 네임스페이스: dev-app (FE+BE+AI 공존), stg-app (동일 구조)
+# Pod 레이블 기준: app: frontend / app: backend / app: ai
+#
+# 트래픽 흐름:
+#   인터넷 → NLB → nginx-gateway → frontend/backend/ai Pod
+#   frontend → backend (8080)
+#   backend  → ai (8000), DB(5432), Redis(6379)
+#   ai       → DB(5432), 외부 AI API(443)
+
+# ══════════════════════════════════════════
+# nginx-gateway 네임스페이스
+# ══════════════════════════════════════════
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: nginx-gateway
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-nginx-gateway
+  namespace: nginx-gateway
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cert-manager
+  egress:
+    - to:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - dev-app
+                  - stg-app
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+---
+# ══════════════════════════════════════════
+# dev-app 네임스페이스 (개발 환경)
+# ══════════════════════════════════════════
+
+# 기본 deny-all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: dev-app
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Frontend Pod 정책
+# ingress: nginx-gateway에서만
+# egress: backend Pod로만 + DNS + AWS API
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend
+  namespace: dev-app
+spec:
+  podSelector:
+    matchLabels:
+      app: frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-gateway
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: backend
+      ports:
+        - port: 8080
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/16
+              - 192.168.0.0/16
+              - 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP
+---
+# Backend Pod 정책
+# ingress: nginx-gateway 또는 frontend Pod에서
+# egress: ai Pod + DB(5432) + Redis(6379) + DNS + AWS API
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend
+  namespace: dev-app
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-gateway
+    - from:
+        - podSelector:
+            matchLabels:
+              app: frontend
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: ai
+      ports:
+        - port: 8000
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.16.20.0/24   # DB 서브넷
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.16.0.0/16    # Redis (VPC 내부)
+      ports:
+        - port: 6379
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/16
+              - 192.168.0.0/16
+              - 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP
+---
+# AI Pod 정책
+# ingress: nginx-gateway 또는 backend Pod에서
+# egress: DB(5432) + 외부 AI API(443) + DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ai
+  namespace: dev-app
+spec:
+  podSelector:
+    matchLabels:
+      app: ai
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-gateway
+    - from:
+        - podSelector:
+            matchLabels:
+              app: backend
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.16.20.0/24   # DB 서브넷
+      ports:
+        - port: 5432
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/16
+              - 192.168.0.0/16
+              - 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP
+
+---
+# ══════════════════════════════════════════
+# stg-app 네임스페이스 (스테이징 환경)
+# dev-app과 동일한 구조
+# ══════════════════════════════════════════
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: stg-app
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend
+  namespace: stg-app
+spec:
+  podSelector:
+    matchLabels:
+      app: frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-gateway
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: backend
+      ports:
+        - port: 8080
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/16
+              - 192.168.0.0/16
+              - 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend
+  namespace: stg-app
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-gateway
+    - from:
+        - podSelector:
+            matchLabels:
+              app: frontend
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: ai
+      ports:
+        - port: 8000
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.16.20.0/24
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.16.0.0/16
+      ports:
+        - port: 6379
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/16
+              - 192.168.0.0/16
+              - 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ai
+  namespace: stg-app
+spec:
+  podSelector:
+    matchLabels:
+      app: ai
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-gateway
+    - from:
+        - podSelector:
+            matchLabels:
+              app: backend
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.16.20.0/24
+      ports:
+        - port: 5432
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/16
+              - 192.168.0.0/16
+              - 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP

--- a/k8s/platform/nginx-gateway/gateway.yaml
+++ b/k8s/platform/nginx-gateway/gateway.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: nginx
+spec:
+  controllerName: gateway.nginx.org/nginx-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: devths-gateway
+  namespace: nginx-gateway
+spec:
+  gatewayClassName: nginx
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: devths-tls
+            namespace: nginx-gateway
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
## 📌 작업한 내용

- Add GatewayClass and Gateway CR for Nginx Gateway Fabric
- Add ClusterIssuer for Let's Encrypt (staging/prod)
- Add ClusterSecretStore for AWS Parameter Store
- Add NetworkPolicy for dev-app/stg-app (pod-label based)
  - frontend: only egress to backend
  - backend: egress to ai, DB(5432), Redis(6379)
  - ai: egress to DB(5432), external AI API(443)

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

closes: #38 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
