### PR TITLE
feat: 백엔드 노드망 RabbitMQ 연결을 위한 NetworkPolicy Egress 포트(5672) 개방 (#42)

### DIFF
--- a/k8s/platform/network-policy/network-policies.yaml
+++ b/k8s/platform/network-policy/network-policies.yaml
@@ -163,6 +163,12 @@ spec:
       ports:
         - port: 6379
           protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.16.10.81/32  # DB EC2 (RabbitMQ)
+      ports:
+        - port: 5672
+          protocol: TCP
     - ports:
         - port: 53
           protocol: UDP
@@ -323,6 +329,12 @@ spec:
             cidr: 172.16.10.81/32  # DB EC2 (Redis)
       ports:
         - port: 6379
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.16.10.81/32  # DB EC2 (RabbitMQ)
+      ports:
+        - port: 5672
           protocol: TCP
     - ports:
         - port: 53


### PR DESCRIPTION
## 📌 작업한 내용

네트워크 정책 수정

## 🔍 참고 사항

nonprod 환경의 d외부 EC2를 통한 DB 설정에 따른 정책 수정
- DB: postgreSQL
- KV DB: Redis
- MQ: rabbitMQ

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

#42 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
