### PR TITLE
fix: argoCD ECR 관련 설정 수정 (#54)

### DIFF
--- a/argocd/applications/dev/ai.yaml
+++ b/argocd/applications/dev/ai.yaml
@@ -16,7 +16,6 @@ metadata:
     # ArgoCD Image Updater 설정
     argocd-image-updater.argoproj.io/image-list: ai=174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/ai-dev
     argocd-image-updater.argoproj.io/ai.update-strategy: latest
-    argocd-image-updater.argoproj.io/ai.allow-tags: regexp:^dev-.*$
     argocd-image-updater.argoproj.io/ai.kustomize.image-name: REPLACE_ME
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main

--- a/argocd/applications/dev/backend.yaml
+++ b/argocd/applications/dev/backend.yaml
@@ -16,7 +16,6 @@ metadata:
     # ArgoCD Image Updater 설정
     argocd-image-updater.argoproj.io/image-list: backend=174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/be-dev
     argocd-image-updater.argoproj.io/backend.update-strategy: latest
-    argocd-image-updater.argoproj.io/backend.allow-tags: regexp:^dev-.*$
     argocd-image-updater.argoproj.io/backend.kustomize.image-name: REPLACE_ME
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main

--- a/argocd/applications/dev/frontend.yaml
+++ b/argocd/applications/dev/frontend.yaml
@@ -15,7 +15,6 @@ metadata:
     # ArgoCD Image Updater 설정
     argocd-image-updater.argoproj.io/image-list: frontend=174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/fe-dev
     argocd-image-updater.argoproj.io/frontend.update-strategy: latest
-    argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^dev-.*$
     argocd-image-updater.argoproj.io/frontend.kustomize.image-name: REPLACE_ME
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main

--- a/k8s-kustomize/overlays/dev/ai/kustomization.yaml
+++ b/k8s-kustomize/overlays/dev/ai/kustomization.yaml
@@ -15,7 +15,7 @@ nameSuffix: -dev
 images:
   - name: REPLACE_ME
     newName: 174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/ai-dev
-    newTag: dev-latest
+    newTag: latest
 
 # overlays 수정내용 반영
 patches:

--- a/k8s-kustomize/overlays/dev/backend/kustomization.yaml
+++ b/k8s-kustomize/overlays/dev/backend/kustomization.yaml
@@ -15,7 +15,7 @@ nameSuffix: -dev
 images:
   - name: REPLACE_ME
     newName: 174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/be-dev
-    newTag: dev-latest
+    newTag: latest
 
 # overlays 수정내용 반영
 patches:

--- a/k8s-kustomize/overlays/dev/frontend/kustomization.yaml
+++ b/k8s-kustomize/overlays/dev/frontend/kustomization.yaml
@@ -15,7 +15,7 @@ nameSuffix: -dev
 images:
   - name: REPLACE_ME
     newName: 174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/fe-dev
-    newTag: dev-latest
+    newTag: latest
 
 # overlays 수정내용 반영
 patches:


### PR DESCRIPTION
## 📌 작업한 내용
ArgoCD의 ECR 이미지 태그 인식 범위를 수정하여 최신 태그가 정상적으로 감지되고 배포되도록 했습니다.  
Image Updater의 태그 필터링 설정을 조정하고 ECR 인증 및 참조 경로를 재구성했습니다.

## 🔍 참고 사항
- Image Updater의 `helmImage` 또는 `kubectl` 전략에서 태그 패턴(예: `semver:range(~1.0.0)`, `latest`, `regexp:^v\d+\.\d+\.\d+$`)을 명확히 정의했습니다.
- ECR Pull Secret이 ArgoCD ServiceAccount에 올바르게 마운트되었는지 확인하세요.
- 테스트 시 ECR에 새로운 태그를 푸시한 후 ArgoCD UI에서 자동 Sync를 관찰하세요.

## 🖼️ 스크린샷
- 수정 전/후 ArgoCD Image Updater 로그 비교
- ECR 태그 목록과 ArgoCD Application 이미지 정보

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/54)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인