### PR TITLE
fix: 레플리카 개수 수정 (#56)

### DIFF
--- a/k8s-kustomize/overlays/dev/ai/deployment.yaml
+++ b/k8s-kustomize/overlays/dev/ai/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 # 스펙
 spec:
   # Replica 개수
-  replicas: 2
+  replicas: 1
 
   # 라벨
   template:

--- a/k8s-kustomize/overlays/dev/backend/deployment.yaml
+++ b/k8s-kustomize/overlays/dev/backend/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 # 스펙
 spec:
   # Replica 개수
-  replicas: 2
+  replicas: 1
 
   # 라벨
   template:

--- a/k8s-kustomize/overlays/dev/frontend/deployment.yaml
+++ b/k8s-kustomize/overlays/dev/frontend/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 # 스펙
 spec:
   # Replica 개수
-  replicas: 2
+  replicas: 1
 
   # 라벨
   template:


### PR DESCRIPTION
## 📌 작업한 내용
클러스터 리소스 안정화를 위해 모든 Deployment의 replica 개수를 1개로 임시 축소했습니다.  
노드 CPU/Memory 부하 완화 및 서비스 운영 지속성을 확보했습니다.

## 🔍 참고 사항
- 모든 네임스페이스의 Deployment/StatefulSet에 대해 `replicas: 1`로 설정
- 트래픽 부하가 정상화되면 replica 수를 단계적으로 원복해야 합니다
- 모니터링 대시보드에서 리소스 사용량이 70% 이하로 안정화되는지 확인하세요

## 🖼️ 스크린샷
- 축소 전/후 노드별 CPU/Memory 사용량 비교
- `kubectl get deployments -A` 결과 (replicas=1 확인)

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/56)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인