### PR TITLE
fix: 이미지 체크 방식 수정 (#60)

### DIFF
--- a/argocd/applications/dev/ai.yaml
+++ b/argocd/applications/dev/ai.yaml
@@ -15,7 +15,8 @@ metadata:
   annotations:
     # ArgoCD Image Updater 설정
     argocd-image-updater.argoproj.io/image-list: ai=174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/ai-dev
-    argocd-image-updater.argoproj.io/ai.update-strategy: latest
+    argocd-image-updater.argoproj.io/ai.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/ai.allow-tags: regexp:^[0-9]{8}_[0-9]{6}-[a-f0-9]{7}$
     argocd-image-updater.argoproj.io/ai.kustomize.image-name: REPLACE_ME
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main

--- a/argocd/applications/dev/backend.yaml
+++ b/argocd/applications/dev/backend.yaml
@@ -15,7 +15,8 @@ metadata:
   annotations:
     # ArgoCD Image Updater 설정
     argocd-image-updater.argoproj.io/image-list: backend=174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/be-dev
-    argocd-image-updater.argoproj.io/backend.update-strategy: latest
+    argocd-image-updater.argoproj.io/backend.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/backend.allow-tags: regexp:^[0-9]{8}_[0-9]{6}-[a-f0-9]{7}$
     argocd-image-updater.argoproj.io/backend.kustomize.image-name: REPLACE_ME
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main

--- a/argocd/applications/dev/frontend.yaml
+++ b/argocd/applications/dev/frontend.yaml
@@ -14,7 +14,8 @@ metadata:
   annotations:
     # ArgoCD Image Updater 설정
     argocd-image-updater.argoproj.io/image-list: frontend=174678835309.dkr.ecr.ap-northeast-2.amazonaws.com/devths/fe-dev
-    argocd-image-updater.argoproj.io/frontend.update-strategy: latest
+    argocd-image-updater.argoproj.io/frontend.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^[0-9]{8}_[0-9]{6}-[a-f0-9]{7}$
     argocd-image-updater.argoproj.io/frontend.kustomize.image-name: REPLACE_ME
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/git-branch: main


### PR DESCRIPTION
## 📌 작업한 내용
ArgoCD Image Updater의 이미지 체크 방식을 수정하여 `latest` 태그 외 semantic 버전 태그(`v1.2.3`, `v1.*` 등)도 정상적으로 인식되도록 했습니다.  
태그 필터링 패턴과 매치 규칙을 조정하여 CI/CD에서 푸시한 모든 버전 태그가 배포에 반영됩니다.

## 🔍 참고 사항
- Image Updater 설정에서 `semver:range(~1.0.0)`, `regexp:^v\d+\.\d+\.\d+$`, `latest` 등 복수 패턴을 지원하도록 수정했습니다.
- ECR 태그 목록을 polling할 때 모든 태그를 조회하도록 API 호출 범위를 확장했습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/60)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인