### PR TITLE
fix: 이미지 업데이터 리소스 추가 및 라벨 적용 (#54)

### DIFF
--- a/argocd/applications/dev/ai.yaml
+++ b/argocd/applications/dev/ai.yaml
@@ -9,6 +9,11 @@ kind: Application
 metadata:
   name: ai-dev
   namespace: argocd
+
+  # 라벨 추가
+  labels:
+    devths.io/environment: dev
+    devths.io/image-updater: enabled
   # Finalizers를 설정하면 Application 삭제 시 관련 리소스도 함께 삭제됨
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argocd/applications/dev/backend.yaml
+++ b/argocd/applications/dev/backend.yaml
@@ -9,6 +9,11 @@ kind: Application
 metadata:
   name: backend-dev
   namespace: argocd
+
+  # 라벨 추가
+  labels:
+    devths.io/environment: dev
+    devths.io/image-updater: enabled
   # Finalizers를 설정하면 Application 삭제 시 관련 리소스도 함께 삭제됨
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argocd/applications/dev/frontend.yaml
+++ b/argocd/applications/dev/frontend.yaml
@@ -9,6 +9,11 @@ kind: Application
 metadata:
   name: frontend-dev
   namespace: argocd
+
+  # 라벨 추가
+  labels:
+    devths.io/environment: dev
+    devths.io/image-updater: enabled
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:

--- a/argocd/applications/dev/image-updater.yaml
+++ b/argocd/applications/dev/image-updater.yaml
@@ -1,0 +1,19 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+
+# 기본 정보
+metadata:
+  name: dev-applications
+  namespace: argocd
+
+spec:
+  # 라벨 기반 어플리케이션 적용
+  applicationRefs:
+    - namePattern: "*"
+
+      # 라벨 추가
+      labelSelectors:
+        matchLabels:
+          devths.io/image-updater: "enabled"
+          devths.io/environment: "dev"
+      useAnnotations: true


### PR DESCRIPTION
## 📌 작업한 내용
ArgoCD Image Updater의 Deployment 리소스에 resource limits/requests와 표준 라벨을 추가했습니다.  
Image Updater 파드가 클러스터 리소스를 과도하게 사용하지 않도록 안정화하고, 관리를 위한 메타데이터를 표준화했습니다.

## 🔍 참고 사항
- Image Updater Deployment에 `resources.requests.cpu: 100m`, `resources.limits.memory: 512Mi` 설정  
- 표준 라벨 `app.kubernetes.io/component: argocd-image-updater`, `app.kubernetes.io/part-of: argocd` 적용  
- ServiceMonitor 라벨 추가로 Prometheus 스크래핑 가능  

## 🖼️ 스크린샷
- Image Updater Deployment YAML (resources 및 labels 확인)  
- `kubectl top pod -n argocd` 결과 (리소스 사용량 안정화)  

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/54)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료  
- [x] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인