### PR TITLE
fix: ECR Credential 표준에 맞도록 수정 (#54)

### DIFF
--- a/argocd/argocd-image-updater-values.yaml
+++ b/argocd/argocd-image-updater-values.yaml
@@ -35,8 +35,10 @@ authScripts:
   scripts:
     ecr-login.sh: |
       #!/bin/sh
-      # AWS CLI를 사용하여 ECR 로그인 토큰 생성
-      aws ecr get-login-password --region ap-northeast-2 2>/dev/null || echo ""
+      set -e
+      
+      PASSWORD="$(aws ecr get-login-password --region ap-northeast-2)"
+      printf 'AWS:%s\n' "$PASSWORD"
 
 # 리소스 제한
 resources:


### PR DESCRIPTION
## 📌 작업한 내용
ArgoCD Image Updater의 ECR Credential을 표준 형식에 맞게 수정했습니다.  
ECR Private Registry 인증 정보(Docker Config JSON)를 Kubernetes Secret 표준에 맞춰 재구성하여 Image Updater가 안정적으로 ECR 이미지를 pull할 수 있도록 했습니다.

## 🔍 참고 사항
- ECR Credential Secret 형식을 `kubernetes.io/dockerconfigjson`으로 표준화
- AWS IAM Role 또는 Access Key 기반 ECR 인증 정보 재설정
- Image Updater ConfigMap의 `registries` 섹션에서 ECR 엔드포인트 및 credential 명시
- `kubectl get secret -n argocd`로 Secret 정상 생성 확인 필요

## 🖼️ 스크린샷
- ECR Credential Secret YAML (type: kubernetes.io/dockerconfigjson 확인)
- ArgoCD Image Updater 로그 (ECR pull 성공 확인)

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/54)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인