### PR TITLE
fix: Notification discord 지원하지않는 문제 수정 (#58)

### DIFF
--- a/argocd/applications/dev/ai.yaml
+++ b/argocd/applications/dev/ai.yaml
@@ -29,11 +29,9 @@ metadata:
     argocd-image-updater.argoproj.io/git-branch: main
 
     # ArgoCD Notifications 설정 (AI Nonprod Discord 채널)
-    notifications.argoproj.io/subscribe.on-deployed.discord.ai-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-failed.discord.ai-nonprod: ""
-    notifications.argoproj.io/subscribe.on-health-degraded.discord.ai-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-running.discord.ai-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-succeeded.discord.ai-nonprod: ""
+    notifications.argoproj.io/subscribe.on-deployed.webhook.ai-nonprod: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.webhook.ai-nonprod: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.webhook.ai-nonprod: ""
 
 spec:
   # ArgoCD 프로젝트 (기본 프로젝트 사용)

--- a/argocd/applications/dev/backend.yaml
+++ b/argocd/applications/dev/backend.yaml
@@ -29,11 +29,9 @@ metadata:
     argocd-image-updater.argoproj.io/git-branch: main
 
     # ArgoCD Notifications 설정 (Backend Nonprod Discord 채널)
-    notifications.argoproj.io/subscribe.on-deployed.discord.backend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-failed.discord.backend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-health-degraded.discord.backend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-running.discord.backend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-succeeded.discord.backend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-deployed.webhook.backend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.webhook.backend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.webhook.backend-nonprod: ""
 
 spec:
   # ArgoCD 프로젝트 (기본 프로젝트 사용)

--- a/argocd/applications/dev/frontend.yaml
+++ b/argocd/applications/dev/frontend.yaml
@@ -30,11 +30,9 @@ metadata:
     argocd-image-updater.argoproj.io/git-branch: main
 
     # ArgoCD Notifications 설정 (Frontend Nonprod Discord 채널)
-    notifications.argoproj.io/subscribe.on-deployed.discord.frontend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-failed.discord.frontend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-health-degraded.discord.frontend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-running.discord.frontend-nonprod: ""
-    notifications.argoproj.io/subscribe.on-sync-succeeded.discord.frontend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-deployed.webhook.frontend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.webhook.frontend-nonprod: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.webhook.frontend-nonprod: ""
 
 # 스펙
 spec:

--- a/k8s-helm/releases/argocd/configmaps/notifications-cm.yaml
+++ b/k8s-helm/releases/argocd/configmaps/notifications-cm.yaml
@@ -1,7 +1,7 @@
 # ===================================
 # ArgoCD Discord 알림 템플릿 및 트리거 설정
 # ===================================
-
+#
 # 사용 방법:
 # 1. kubectl apply -f k8s-helm/releases/argocd/configmaps/notifications-cm.yaml
 # ===================================
@@ -17,148 +17,621 @@ metadata:
 # 데이터
 data:
   # ===================================
-  # Discord 서비스 설정
+  # Discord Webhook 서비스 설정
   # ===================================
+  # Discord는 webhook 타입으로 설정해야 합니다
+
   # Frontend Nonprod (Dev + Staging)
-  service.discord.frontend-nonprod: |
-    token: $discord-frontend-nonprod-webhook
+  service.webhook.frontend-nonprod: |
+    url: $discord-frontend-nonprod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
 
   # Backend Nonprod (Dev + Staging)
-  service.discord.backend-nonprod: |
-    token: $discord-backend-nonprod-webhook
+  service.webhook.backend-nonprod: |
+    url: $discord-backend-nonprod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
 
   # AI Nonprod (Dev + Staging)
-  service.discord.ai-nonprod: |
-    token: $discord-ai-nonprod-webhook
+  service.webhook.ai-nonprod: |
+    url: $discord-ai-nonprod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
 
   # Frontend Production
-  service.discord.frontend-prod: |
-    token: $discord-frontend-prod-webhook
+  service.webhook.frontend-prod: |
+    url: $discord-frontend-prod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
 
   # Backend Production
-  service.discord.backend-prod: |
-    token: $discord-backend-prod-webhook
+  service.webhook.backend-prod: |
+    url: $discord-backend-prod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
 
   # AI Production
-  service.discord.ai-prod: |
-    token: $discord-ai-prod-webhook
+  service.webhook.ai-prod: |
+    url: $discord-ai-prod-webhook
+    headers:
+    - name: Content-Type
+      value: application/json
 
   # ===================================
   # 템플릿: 배포 완료 (Deployed)
   # ===================================
   template.app-deployed: |
-    discord:
-      title: "✅ 배포 완료"
-      description: |
-        **환경**: {{.app.metadata.labels.environment | upper}}
-        **애플리케이션**: {{.app.metadata.name}}
-        **네임스페이스**: {{.app.spec.destination.namespace}}
-        **리포지토리**: {{call .repo.FullNameByRepoURL .app.spec.source.repoURL}}
-        **리비전**: {{.app.status.sync.revision | substr 0 7}}
-        **배포 시각**: {{.app.status.operationState.finishedAt}}
-      color: 3066993
-      fields:
-      - name: "🌍 Environment"
-        value: "{{.app.metadata.labels.environment | upper}}"
-        inline: true
-      - name: "📦 Application"
-        value: "{{.app.metadata.name}}"
-        inline: true
-      - name: "🔗 ArgoCD URL"
-        value: "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})"
-        inline: false
+    webhook:
+      frontend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}\n**리비전**: {{.app.status.sync.revision | substr 0 7}}",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
+      backend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}\n**리비전**: {{.app.status.sync.revision | substr 0 7}}",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
+      ai-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}\n**리비전**: {{.app.status.sync.revision | substr 0 7}}",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
+      frontend-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}\n**리비전**: {{.app.status.sync.revision | substr 0 7}}",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
+      backend-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}\n**리비전**: {{.app.status.sync.revision | substr 0 7}}",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
+      ai-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 완료",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}\n**리비전**: {{.app.status.sync.revision | substr 0 7}}",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ],
+              "timestamp": "{{.app.status.operationState.finishedAt}}"
+            }]
+          }
 
   # ===================================
   # 템플릿: 동기화 실패 (Sync Failed)
   # ===================================
   template.app-sync-failed: |
-    discord:
-      title: "❌ 동기화 실패"
-      description: |
-        **환경**: {{.app.metadata.labels.environment | upper}}
-        **애플리케이션**: {{.app.metadata.name}}
-        **네임스페이스**: {{.app.spec.destination.namespace}}
-        **에러 메시지**: {{.app.status.operationState.message}}
-      color: 15158332
-      fields:
-      - name: "🌍 Environment"
-        value: "{{.app.metadata.labels.environment | upper}}"
-        inline: true
-      - name: "📦 Application"
-        value: "{{.app.metadata.name}}"
-        inline: true
-      - name: "🔗 ArgoCD URL"
-        value: "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})"
-        inline: false
-      - name: "⚠️ 에러"
-        value: "{{.app.status.operationState.message}}"
-        inline: false
+    webhook:
+      frontend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ 에러",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      backend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ 에러",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      ai-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ 에러",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      frontend-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ 에러",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      backend-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ 에러",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      ai-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 동기화 실패",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**네임스페이스**: {{.app.spec.destination.namespace}}",
+              "color": 15158332,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "⚠️ 에러",
+                  "value": "{{.app.status.operationState.message}}",
+                  "inline": false
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
 
   # ===================================
   # 템플릿: 헬스 체크 이상 (Health Degraded)
   # ===================================
   template.app-health-degraded: |
-    discord:
-      title: "⚠️ 헬스 체크 이상"
-      description: |
-        **환경**: {{.app.metadata.labels.environment | upper}}
-        **애플리케이션**: {{.app.metadata.name}}
-        **네임스페이스**: {{.app.spec.destination.namespace}}
-        **헬스 상태**: {{.app.status.health.status}}
-        **메시지**: {{.app.status.health.message}}
-      color: 16776960
-      fields:
-      - name: "🌍 Environment"
-        value: "{{.app.metadata.labels.environment | upper}}"
-        inline: true
-      - name: "📦 Application"
-        value: "{{.app.metadata.name}}"
-        inline: true
-      - name: "🏥 Health Status"
-        value: "{{.app.status.health.status}}"
-        inline: true
-      - name: "🔗 ArgoCD URL"
-        value: "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})"
-        inline: false
-
-  # ===================================
-  # 템플릿: 동기화 시작
-  # ===================================
-  template.app-sync-running: |
-    discord:
-      title: "🔄 동기화 시작"
-      description: |
-        **환경**: {{.app.metadata.labels.environment | upper}}
-        **애플리케이션**: {{.app.metadata.name}}
-        **네임스페이스**: {{.app.spec.destination.namespace}}
-      color: 6737151
-      fields:
-      - name: "🌍 Environment"
-        value: "{{.app.metadata.labels.environment | upper}}"
-        inline: true
-      - name: "📦 Application"
-        value: "{{.app.metadata.name}}"
-        inline: true
-
-  # ===================================
-  # 템플릿: 동기화 성공
-  # ===================================
-  template.app-sync-succeeded: |
-    discord:
-      title: "✅ 동기화 성공"
-      description: |
-        **환경**: {{.app.metadata.labels.environment | upper}}
-        **애플리케이션**: {{.app.metadata.name}}
-        **네임스페이스**: {{.app.spec.destination.namespace}}
-        **리비전**: {{.app.status.sync.revision | substr 0 7}}
-      color: 3066993
-      fields:
-      - name: "🌍 Environment"
-        value: "{{.app.metadata.labels.environment | upper}}"
-        inline: true
-      - name: "📦 Application"
-        value: "{{.app.metadata.name}}"
-        inline: true
+    webhook:
+      frontend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**헬스 상태**: {{.app.status.health.status}}",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      backend-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**헬스 상태**: {{.app.status.health.status}}",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      ai-nonprod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**헬스 상태**: {{.app.status.health.status}}",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      frontend-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**헬스 상태**: {{.app.status.health.status}}",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      backend-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**헬스 상태**: {{.app.status.health.status}}",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
+      ai-prod:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 헬스 체크 이상",
+              "description": "**환경**: {{.app.metadata.labels.environment | upper}}\n**애플리케이션**: {{.app.metadata.name}}\n**헬스 상태**: {{.app.status.health.status}}",
+              "color": 16776960,
+              "fields": [
+                {
+                  "name": "🌍 Environment",
+                  "value": "{{.app.metadata.labels.environment | upper}}",
+                  "inline": true
+                },
+                {
+                  "name": "📦 Application",
+                  "value": "{{.app.metadata.name}}",
+                  "inline": true
+                },
+                {
+                  "name": "🏥 Health Status",
+                  "value": "{{.app.status.health.status}}",
+                  "inline": true
+                },
+                {
+                  "name": "🔗 ArgoCD URL",
+                  "value": "[바로가기]({{.context.argocdUrl}}/applications/{{.app.metadata.name}})",
+                  "inline": false
+                }
+              ]
+            }]
+          }
 
   # ===================================
   # 트리거 설정
@@ -183,17 +656,3 @@ data:
       send:
       - app-health-degraded
       when: app.status.health.status == 'Degraded'
-
-  # 동기화 시작 시 알림
-  trigger.on-sync-running: |
-    - description: Application is being synced
-      send:
-      - app-sync-running
-      when: app.status.operationState.phase in ['Running']
-
-  # 동기화 성공 시 알림
-  trigger.on-sync-succeeded: |
-    - description: Application syncing has succeeded
-      send:
-      - app-sync-succeeded
-      when: app.status.operationState.phase in ['Succeeded']


### PR DESCRIPTION
## 📌 작업한 내용
ArgoCD Notifications에서 Discord 채널 지원을 추가하여 알림 전송이 가능하도록 수정했습니다.  
ConfigMap에 Discord Webhook 설정을 추가하고, Template에서 Discord 전용 formatter를 정의했습니다.

## 🔍 참고 사항
- [ArgoCD 공식 문서 참조](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/services/overview/?utm_source=chatgpt.com)

## 🖼️ 스크린샷

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/58)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인