### PR TITLE
feat: Git 변경 감지 시간 주기 단축 (#58)

### DIFF
--- a/k8s-helm/releases/argocd/values-nonprod.yaml.example
+++ b/k8s-helm/releases/argocd/values-nonprod.yaml.example
@@ -1,5 +1,10 @@
 # Copy to values-nonprod.yaml and add argo/argo-cd overrides here.
 # Example:
-# global:
-#   domain: nonprod.argo.example.com
-{}
+global:
+  domain: nonprod.argo.devths.com
+
+configs:
+  cm:
+    # Git/Helm 변경 감지 주기.
+    timeout.reconciliation: "60s"
+    timeout.reconciliation.jitter: "15s"


### PR DESCRIPTION
## 📌 작업한 내용
ArgoCD의 Git 변경 감지(poll 간격)를 단축하여 배포 반영 시간을 단축했습니다.  
기본 3분 간격에서 30초 또는 1분 간격으로 조정하여 CI/CD 파이프라인의 반응성을 높였습니다.

## 🔍 참고 사항
- ArgoCD Application의 `syncPolicy.syncOptions: [Prune=false, SelfHeal=true]` 유지  
- repo-server 및 application-controller 리소스 사용량 모니터링 필요  
- `argocd app get <app-name> --refresh` 또는 UI에서 변경 감지 속도 확인  
- 부하 증가 시 polling 간격을 1분~2분으로 조정하세요  

## 🖼️ 스크린샷
- 수정된 Application YAML (간격 설정 부분)  
- main 브랜치 푸시 → ArgoCD Sync 완료 시간 비교  

## 🔗 관련 이슈
(https://github.com/100-hours-a-week/9-team-Devths-CLOUD/issues/58)

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료  
- [x] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인